### PR TITLE
#23 Fix bug in README filtering examples 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+.DS_Store

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,5 +15,6 @@ LazyData: true
 Depends:
     SPARQL
 Suggests:
-    readr
+    readr,
+    testthat
 RoxygenNote: 6.1.0

--- a/R/scotgov_get.R
+++ b/R/scotgov_get.R
@@ -121,7 +121,7 @@ scotgov_get <- function(dataset,
   #expose the measureType dimension's value as a value
   query <- paste(query, "?data ?measureTypeURI ?value. }")
 
-  query_data <- try(SPARQL::SPARQL(endpoint, query), silent = TRUE)
+  query_data <- try(SPARQL::SPARQL(endpoint, query[1]), silent = TRUE)
   if ( query_data[1] ==
        "Error : XML content does not seem to be XML: 'Response too large'\n"){
     stop(Error = paste("Dataset is too large to be downloaded like this.",

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(scotgov)
+
+test_check("scotgov")

--- a/tests/testthat/test_scotgov.R
+++ b/tests/testthat/test_scotgov.R
@@ -1,0 +1,30 @@
+context("scotgov")
+
+
+test_that("scotgov_get with geography filtering produces no warning", {
+
+  expect_silent(scotgov_get(dataset = "average-household-size", geography = "S12000039"))
+
+})
+
+
+test_that("scotgov_get with start date filtering produces no warning", {
+
+  expect_silent(scotgov_get(dataset = "average-household-size",
+                            start_date = 2010))
+
+})
+
+test_that("scotgov_get with end date filtering produces no warning", {
+
+  expect_silent(scotgov_get(dataset = "average-household-size",
+                            end_date = 2010))
+
+})
+
+test_that("scotgov_get with date and geography filtering produces no warning", {
+
+  expect_silent(scotgov_get(dataset = "average-household-size",
+                            end_date = 2010, geography = "S12000039"))
+
+})


### PR DESCRIPTION
- added a small workaround for the warning messages when querying with additional filters. After checking for all the filters the length of the query is actually 3 and I think it is the same String for all elements. So the workaround is to just give the first element to the function.

- added according testthat tests