### PR TITLE
added lintr package and after success command to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,10 @@
 language: R
 sudo: false
 cache: packages
+
+r_github_packages:
+  - jimhester/lintr
+  
+after_success:
+  - R CMD INSTALL $PKG_TARBALL
+  - Rscript -e 'lintr::lint_package()'


### PR DESCRIPTION
There are two ways to add lintr for continuous integration, from the documentation:
- either using lintr::lint_package as a after_success step in your build process, which we recommend
- or setting an testthat unit test, which might take a long time to run and hinder development.

I used the recommended method. It doesn't fail the Travis checks, but results are visible the Travis log or in github by clicking on the speech bubble icon next to the commit.