### PR TITLE
added @noRd to get_categories and get_names

### DIFF
--- a/R/get_categories.r
+++ b/R/get_categories.r
@@ -1,5 +1,6 @@
 # SPARQL query to get all unique values of a dataset dimension
 # internal function for scotgov_get
+#' @noRd
 
 get_categories <- function(dataset,dimension) {
 

--- a/R/get_names.r
+++ b/R/get_names.r
@@ -1,6 +1,7 @@
 # small function to transform sparql location to a simple name
 # can be removed when dataset_structure and dataset_measures return clear labels
 # internal function for scotgov_get
+#' @noRd 
 
 get_names <- function(dataset) {
 


### PR DESCRIPTION
I think this might be unnecessary as the two non-public functions (get_names and get_categories) currently don't build rd files as it is, as they don't contain roxygen documentation:

https://stackoverflow.com/questions/2316356/can-roxygen-ignore-non-user-functions

I think previous versions might have still created an rd file if the r function didn't contain roxygen, hence the advice to add @noRd. But also I don't see any harm in explicitly specifying noRd, so I'll leave it up to you whether to accept the pull request!
