### PR TITLE
#27test coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ cache: packages
 
 r_github_packages:
   - jimhester/lintr
+  - r-lib/covr
   
 after_success:
   - R CMD INSTALL $PKG_TARBALL
   - Rscript -e 'lintr::lint_package()'
+  - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,8 @@ Suggests:
     readr,
     knitr,
     rmarkdown,
-    testthat
+    testthat,
+    covr
 RoxygenNote: 6.1.0
 VignetteBuilder: knitr
 Language: en-GB


### PR DESCRIPTION
You can see the reports produced in the tick next to the commit. I'm assuming that there will be more detail when the .R files are changed as that's what it's set up to cover, but haven't tested that yet. When I come to the unit tests issue I'll look at the output in more detail.